### PR TITLE
Add coming soon placeholder homepage

### DIFF
--- a/the-turnstile-nextjs/src/pages/index.tsx
+++ b/the-turnstile-nextjs/src/pages/index.tsx
@@ -1,52 +1,21 @@
-import { useEffect, useState } from "react";
-
-import { loadJSON } from "@/lib/data";
-import type { Match } from "@/types";
-
-type DataStatus = "loading" | "ok" | "fail";
-
 export default function Home() {
-  const [status, setStatus] = useState<DataStatus>("loading");
-  const [matches, setMatches] = useState<Match[]>([]);
-
-  useEffect(() => {
-    let cancelled = false;
-
-    const loadMatches = async () => {
-      try {
-        const result = await loadJSON<Match[]>("/data/matches.json");
-
-        if (cancelled) {
-          return;
-        }
-
-        setMatches(result);
-        setStatus(result.length > 0 ? "ok" : "fail");
-      } catch (error) {
-        if (!cancelled) {
-          console.error("Failed to load matches", error);
-          setMatches([]);
-          setStatus("fail");
-        }
-      }
-    };
-
-    loadMatches();
-
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   return (
-    <main style={{ padding: 24, fontFamily: "system-ui, Arial" }}>
-      <h1>The Turnstile</h1>
-      <p>
-        Data status: <strong>{status}</strong>
-      </p>
-      <p>
-        Matches loaded: <strong>{matches.length}</strong>
-      </p>
+    <main
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        padding: 24,
+        fontFamily: "system-ui, -apple-system, BlinkMacSystemFont, \"Segoe UI\", sans-serif",
+        textAlign: "center",
+        backgroundColor: "#f5f7fa",
+        color: "#0f172a",
+      }}
+    >
+      <h1 style={{ fontSize: "2.5rem", marginBottom: "0.75rem" }}>The Turnstile</h1>
+      <p style={{ fontSize: "1.25rem", margin: 0 }}>Coming soon.</p>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- replace the existing homepage with a full-screen placeholder design
- display a simple "The Turnstile" heading with a "Coming soon." message

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e426c21f18832c8713061b5e83e9a7