### PR TITLE
Add global styling and provider setup for Next.js app

### DIFF
--- a/the-turnstile-nextjs/src/pages/_app.tsx
+++ b/the-turnstile-nextjs/src/pages/_app.tsx
@@ -1,0 +1,15 @@
+import type { AppProps } from "next/app";
+
+import "../styles/globals.css";
+
+import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
+import { AuthProvider } from "@/contexts/AuthContext";
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <AuthProvider>
+      <ServiceWorkerRegister />
+      <Component {...pageProps} />
+    </AuthProvider>
+  );
+}

--- a/the-turnstile-nextjs/src/styles/globals.css
+++ b/the-turnstile-nextjs/src/styles/globals.css
@@ -32,8 +32,8 @@
     --clr-primary: #b71e3c;
     --clr-secondary: #ffdd57;
     --clr-accent: #0074ff;
-    --clr-danger: #b71e3c;
-    --clr-warning: #ffdd57;
+    --clr-danger: var(--clr-primary);
+    --clr-warning: var(--clr-secondary);
     --clr-info: #3b82f6;
     --clr-success: #22c55e;
     --clr-text-strong: #ffffff;

--- a/the-turnstile-nextjs/src/styles/globals.css
+++ b/the-turnstile-nextjs/src/styles/globals.css
@@ -10,9 +10,9 @@
     --clr-primary: #7f1028;
     --clr-secondary: #ffd447;
     --clr-accent: #0052cc;
-    --clr-danger: #7f1028;
-    --clr-warning: #ffd447;
-    --clr-info: #0052cc;
+    --clr-danger: var(--clr-primary);
+    --clr-warning: var(--clr-secondary);
+    --clr-info: var(--clr-accent);
     --clr-success: #00a86b;
     --clr-text-strong: #121212;
     --clr-text: #333333;

--- a/the-turnstile-nextjs/src/styles/globals.css
+++ b/the-turnstile-nextjs/src/styles/globals.css
@@ -1,0 +1,70 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  :root {
+    --font-roboto: "Roboto", "Inter", "Helvetica Neue", Arial, sans-serif;
+    --font-heading: "Bebas Neue", "Anton", "Oswald", "Arial Narrow", sans-serif;
+
+    --clr-primary: #7f1028;
+    --clr-secondary: #ffd447;
+    --clr-accent: #0052cc;
+    --clr-danger: #7f1028;
+    --clr-warning: #ffd447;
+    --clr-info: #0052cc;
+    --clr-success: #00a86b;
+    --clr-text-strong: #121212;
+    --clr-text: #333333;
+    --clr-text-subtle: #666666;
+    --clr-border: #dddddd;
+    --clr-surface: #ffffff;
+    --clr-surface-alt: #f5f5f5;
+    --gradient-1: linear-gradient(140deg, rgba(127, 16, 40, 0.12), rgba(0, 82, 204, 0.1));
+    --gradient-2: radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.18), transparent 55%);
+    --gradient-3: radial-gradient(circle at 80% 0%, rgba(127, 16, 40, 0.14), transparent 45%);
+    color: var(--clr-text);
+    background-color: var(--clr-surface);
+    color-scheme: light;
+  }
+
+  .dark {
+    --clr-primary: #b71e3c;
+    --clr-secondary: #ffdd57;
+    --clr-accent: #0074ff;
+    --clr-danger: #b71e3c;
+    --clr-warning: #ffdd57;
+    --clr-info: #3b82f6;
+    --clr-success: #22c55e;
+    --clr-text-strong: #ffffff;
+    --clr-text: #e0e0e0;
+    --clr-text-subtle: #a0a0a0;
+    --clr-border: #404040;
+    --clr-surface: #1a1a1a;
+    --clr-surface-alt: #2c2c2c;
+    --gradient-1: linear-gradient(140deg, rgba(183, 30, 60, 0.24), rgba(0, 116, 255, 0.18));
+    --gradient-2: radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.22), transparent 60%);
+    --gradient-3: radial-gradient(circle at 90% 10%, rgba(183, 30, 60, 0.2), transparent 55%);
+    color: var(--clr-text);
+    background-color: var(--clr-surface);
+    color-scheme: dark;
+  }
+
+  body {
+    font-family: var(--font-roboto);
+    background-color: var(--clr-surface);
+    color: var(--clr-text);
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-heading);
+    color: var(--clr-text-strong);
+  }
+}

--- a/the-turnstile-nextjs/tailwind.config.ts
+++ b/the-turnstile-nextjs/tailwind.config.ts
@@ -5,6 +5,7 @@ const config: Config = {
     "./src/pages/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/components/**/*.{js,ts,jsx,tsx,mdx}",
     "./src/app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./src/styles/**/*.{css,scss}",
   ],
   darkMode: "class", // or 'media'
   theme: {


### PR DESCRIPTION
## Summary
- add a Tailwind-powered global stylesheet that defines the design token variables and base typography defaults
- update the Tailwind configuration to watch the new styles directory for class usage
- create a custom Next.js App component that imports the globals, wraps pages in the AuthProvider, and initialises the service worker registration singleton

## Testing
- npm run lint *(fails: `next` command not found because dependencies are not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e496eba9e4832c9f91263fbc6292e0