### PR TITLE
Fix Firebase API routing for hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -6,6 +6,9 @@
     "headers": [
       { "source": "**/*.@(js|css)", "headers": [{ "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }] },
       { "source": "/index.html", "headers": [{ "key": "Cache-Control", "value": "no-store" }] }
+    ],
+    "rewrites": [
+      { "source": "/api/**", "function": "api" }
     ]
   }
 }

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -9,7 +9,12 @@ const app = express();
 app.use(express.json());
 app.use(cors());
 
-app.get("/health", (_req, res) => res.json({ ok: true }));
-app.get("/matches", (_req, res) => res.json({ matches: [] }));
+const apiRouter = express.Router();
+
+apiRouter.get("/health", (_req, res) => res.json({ ok: true }));
+apiRouter.get("/matches", (_req, res) => res.json({ matches: [] }));
+
+app.use("/api", apiRouter);
+app.use(apiRouter);
 
 export const api = functions.https.onRequest(app);


### PR DESCRIPTION
## Summary
- add a Firebase Hosting rewrite so /api/* requests are forwarded to the Cloud Function
- mount an Express router at /api to serve health and matches endpoints through the function while keeping legacy paths working

## Testing
- npm --prefix functions run build

------
https://chatgpt.com/codex/tasks/task_e_68e4b67509c0832c9f3c68328d66d989