### PR TITLE
Fix dev script cleanup to avoid missing rimraf dependency

### DIFF
--- a/the-turnstile-nextjs/package.json
+++ b/the-turnstile-nextjs/package.json
@@ -3,13 +3,13 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-  "dev": "npm run clean && next dev",
-  "build": "next build",
-  "start": "next start",
-  "lint": "next lint",
-  "test": "jest",
-  "clean": "rimraf ./.next"
-},
+    "dev": "npm run clean && next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "test": "jest",
+    "clean": "node -e \"require('fs').rmSync('.next', { recursive: true, force: true })\""
+  },
   "dependencies": {
     "@sentry/react": "^7.119.0",
     "firebase-admin": "12.2.0",


### PR DESCRIPTION
## Summary
- replace the rimraf-based clean step with a Node fs.rmSync call so the dev server no longer depends on a missing package
- keep the rest of the workflow unchanged so `npm run dev` still clears `.next` before starting Next.js

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e503f11f3c832cb6148177b945bc83