### PR TITLE
Add AuthUser type definition to shared types

### DIFF
--- a/types.ts
+++ b/types.ts
@@ -100,6 +100,17 @@ export interface User {
   avatarUrl?: string;
 }
 
+// Represents the authenticated user details that we persist locally. This mirrors the
+// properties populated from Google Identity Services so components can rely on a single
+// shape whether the user is online or using the offline guest profile.
+export interface AuthUser {
+  uid: string;
+  displayName?: string;
+  email?: string | null;
+  avatarUrl?: string | null;
+  isAnonymous: boolean;
+}
+
 export interface StadiumInfo {
   name: string;
   capacity: string;


### PR DESCRIPTION
## Summary
- add the missing `AuthUser` interface to `types.ts` so components and the auth context compile against a consistent shape for authenticated users

## Testing
- npm run build *(fails: Vite cannot resolve `react/jsx-runtime` because React dependencies are unavailable in the provided environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e514c19ecc832ca1dc8c6d647c7256