### PR TITLE
Configure Google Sign-In client

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_GOOGLE_CLIENT_ID=99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ npm install
 ### 2. Configure Google Sign-In
 
 Copy the example environment file and update the placeholder with your Google OAuth web client ID. The value must match the
-client configured for this project's origin in the Google Cloud Console.
+client configured for this project's origin in the Google Cloud Console. If you are using the hosted demo credentials,
+set `VITE_GOOGLE_CLIENT_ID` to `99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com`.
 
 ```bash
 cp .env.example .env.local


### PR DESCRIPTION
## Summary
- add a committed `.env` so Vite exposes the Google OAuth client ID needed for Sign-In
- document the hosted demo client ID in the setup instructions for convenience

## Testing
- `npm run build` *(fails: existing TypeScript compile errors in App.tsx – missing React hook imports)*

------
https://chatgpt.com/codex/tasks/task_e_68e58264f900832ca90578b230bf487d