### PR TITLE
Add default Google client ID configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,4 @@ VITE_FIREBASE_MEASUREMENT_ID=
 VITE_USE_FIREBASE_EMULATORS=false
 
 # Google OAuth configuration
-VITE_GOOGLE_CLIENT_ID=your-web-client-id.apps.googleusercontent.com
+VITE_GOOGLE_CLIENT_ID=99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -7,6 +7,9 @@ import {
   MiniSpinnerIcon,
 } from './Icons';
 
+const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID ??
+  '99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com').trim();
+
 type AuthMode = 'login' | 'signup' | 'forgot';
 
 interface LoginPromptViewProps {
@@ -62,7 +65,7 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
   });
   const [forgotForm, setForgotForm] = useState({ email: '' });
 
-  const isGoogleConfigured = useMemo(() => Boolean(import.meta.env.VITE_GOOGLE_CLIENT_ID), []);
+  const isGoogleConfigured = useMemo(() => Boolean(GOOGLE_CLIENT_ID), []);
   const canUseGoogle = Boolean(onLogin) && isGoogleConfigured;
 
   useEffect(() => {

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -82,6 +82,8 @@ const LOCAL_AUTH_KEY = 'scrum-book:auth-user';
 const GOOGLE_IDENTITY_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
 const LOCAL_ACCOUNTS_KEY = 'scrum-book:accounts';
 const LOCAL_PASSWORD_RESET_PREFIX = 'scrum-book:password-reset-requested';
+const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID ??
+  '99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com').trim();
 
 interface StoredAccount {
   id: string;
@@ -456,7 +458,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const login = async () => {
     setLoading(true);
     try {
-      const clientId = import.meta.env.VITE_GOOGLE_CLIENT_ID;
+      const clientId = GOOGLE_CLIENT_ID;
       if (!clientId) {
         throw new Error(
           'Google Sign-In is not configured. Set the VITE_GOOGLE_CLIENT_ID environment variable to your OAuth client ID.'


### PR DESCRIPTION
## Summary
- add a fallback Google client ID for the login prompt and auth context
- update the example environment file with the production Google client ID

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5eb31c918832c9eade0124bbc612e