### PR TITLE
Require explicit Google client ID for sign-in

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,4 +11,5 @@ VITE_FIREBASE_MEASUREMENT_ID=
 VITE_USE_FIREBASE_EMULATORS=false
 
 # Google OAuth configuration
-VITE_GOOGLE_CLIENT_ID=99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com
+# Replace with your Google OAuth Web client ID (required for Google Sign-In)
+VITE_GOOGLE_CLIENT_ID=

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ npm install
 
 ### 2. Configure Google Sign-In
 
-Copy the example environment file and update the placeholder with your Google OAuth web client ID. The value must match the
-client configured for this project's origin in the Google Cloud Console. If you are using the hosted demo credentials,
-set `VITE_GOOGLE_CLIENT_ID` to `99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com`.
+Copy the example environment file and update the placeholder with your Google OAuth web client ID (it looks like
+`1234567890-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com`). The value must match the client configured for
+this project's origin in the Google Cloud Console. Without a valid ID the Google button stays disabled in the UI.
 
 ```bash
 cp .env.example .env.local
@@ -104,7 +104,7 @@ This build runs entirely offline using localStorage. To connect your own Firebas
 
 1. In the Firebase console, open **Build → Authentication → Sign-in method** and enable the **Google** provider. Configure the support email when prompted so users can sign in with their Google account.
 2. Still in **Project settings → General**, scroll to **Your apps** and add the SHA-1 release fingerprint for every Android app that should support Google Sign-In. This step is required for Google to trust the OAuth client.
-3. In **Project settings → General → Your project**, update the **Public-facing name** so it matches `project-99200945430`. Firebase uses this value during the Google account consent screen.
+3. In **Project settings → General → Your project**, update the **Public-facing name** so it matches the project configured for your OAuth client. Firebase uses this value during the Google account consent screen.
 4. Update your `.env.local` file in the project root with your web client ID so the frontend can call Google directly:
 
    ```bash

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -7,8 +7,9 @@ import {
   MiniSpinnerIcon,
 } from './Icons';
 
-const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID ??
-  '99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com').trim();
+const GOOGLE_CLIENT_ID = typeof import.meta.env.VITE_GOOGLE_CLIENT_ID === 'string'
+  ? import.meta.env.VITE_GOOGLE_CLIENT_ID.trim()
+  : '';
 
 type AuthMode = 'login' | 'signup' | 'forgot';
 

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -82,8 +82,9 @@ const LOCAL_AUTH_KEY = 'scrum-book:auth-user';
 const GOOGLE_IDENTITY_SCRIPT_SRC = 'https://accounts.google.com/gsi/client';
 const LOCAL_ACCOUNTS_KEY = 'scrum-book:accounts';
 const LOCAL_PASSWORD_RESET_PREFIX = 'scrum-book:password-reset-requested';
-const GOOGLE_CLIENT_ID = (import.meta.env.VITE_GOOGLE_CLIENT_ID ??
-  '99200945430-kr928f1b59vma8d9ulck20un5mqw6sfl.apps.googleusercontent.com').trim();
+const GOOGLE_CLIENT_ID = typeof import.meta.env.VITE_GOOGLE_CLIENT_ID === 'string'
+  ? import.meta.env.VITE_GOOGLE_CLIENT_ID.trim()
+  : '';
 
 interface StoredAccount {
   id: string;


### PR DESCRIPTION
## Summary
- stop shipping a hard-coded Google OAuth client ID so sign-in is only offered when a valid ID is configured
- update the auth context and login prompt to read a sanitised `VITE_GOOGLE_CLIENT_ID` value from the environment
- document the configuration requirement and adjust the example env file to use a placeholder

## Testing
- npm run build *(fails: existing TypeScript errors in App.tsx unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e60246e460832cb9d4638bcb6b6291