### PR TITLE
Update branding references to The Turnstile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 ```md
-# The Scrum Book
+# The Turnstile
 
-![The Scrum Book logo](public/logo.png)
+![The Turnstile logo](public/logo.png)
 
-The Scrum Book is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
+The Turnstile is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
 
 ---
 
@@ -12,7 +12,7 @@ The Scrum Book is a modern React + Vite application that helps rugby league fans
 
 - **Match Browser** — search and filter the full season fixture list and mark games you attended.
 - **Match Day dashboards** — jump to the fixtures happening soon or near you with tailored views.
-- **My Scrum Book** — track total matches, unique venues, and revisit the games you have already logged.
+- **My Turnstile** — track total matches, unique venues, and revisit the games you have already logged.
 - **Offline-friendly seed data** — local fixtures and venues power the UI until you wire up Firestore.
 
 ---

--- a/components/AboutView.tsx
+++ b/components/AboutView.tsx
@@ -34,7 +34,7 @@ interface FeatureCard {
 const highlightCards: HighlightCard[] = [
   {
     title: 'Your Digital Match Day Diary',
-    description: 'The Scrum Book is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
+    description: 'The Turnstile is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
     icon: SparklesIcon,
     accent: 'from-primary/80 to-secondary/70',
     footer: 'Never forget a match day memory.',
@@ -120,13 +120,13 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
           <div>
             <div className="mb-6 flex items-center gap-3 text-primary">
               <LogoIcon className="h-10 w-10" theme={theme} />
-              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Turnstile</span>
             </div>
             <h1 className="text-4xl font-bold text-text-strong md:text-5xl">
               Your Ultimate Rugby League Companion
             </h1>
             <p className="mt-5 max-w-2xl text-lg text-text">
-              The Scrum Book is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.
+              The Turnstile is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.
             </p>
             <div className="mt-8 flex flex-wrap gap-4 text-sm">
               <div className="flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 font-semibold text-primary">
@@ -259,9 +259,9 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
       </section>
 
       <section className="rounded-3xl border border-border/80 bg-surface-alt/80 p-8 text-center shadow-card">
-        <h2 className="text-2xl font-bold text-text-strong">Join The Scrum Book Community</h2>
+        <h2 className="text-2xl font-bold text-text-strong">Join The Turnstile Community</h2>
         <p className="mt-2 text-text">
-          Start building your fan legacy today. The Scrum Book is your home for all your rugby league memories and connections.
+          Start building your fan legacy today. The Turnstile is your home for all your rugby league memories and connections.
         </p>
         <p className="mt-4 text-sm font-medium uppercase tracking-[0.2em] text-text-subtle">
           Track. Share. Celebrate.

--- a/components/DataUploader.tsx
+++ b/components/DataUploader.tsx
@@ -13,7 +13,7 @@ export const DataUploader: React.FC = () => {
       </div>
 
       <p className="text-text-subtle mb-6">
-        The Scrum Book runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
+        The Turnstile runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
       </p>
 
       <div className="rounded-md border border-warning/30 bg-warning/10 p-4 text-warning flex items-center gap-3">

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -23,7 +23,7 @@ export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', 
   return (
     <img
       src={resolvedSrc}
-      alt={alt ?? 'The Scrum Book logo'}
+      alt={alt ?? 'The Turnstile logo'}
       className={className}
       loading="lazy"
       style={{

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -231,7 +231,7 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
           <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0px_15px_35px_rgba(3,19,31,0.45)]">
             <LogoIcon className="h-12 w-12 drop-shadow" theme={theme} />
           </div>
-          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Turnstile</p>
           <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
           <p className="mt-3 max-w-xs text-sm text-white/60">
             Sign in to manage your matchdays, track your stats, and stay connected with the rugby league community.

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -42,7 +42,7 @@ const primaryItems: NavItem[] = [
   { view: 'LEAGUE_TABLE', label: 'League Table', description: 'Track club standings', icon: TableCellsIcon },
   { view: 'GROUNDS', label: 'Grounds', description: 'Explore Super League stadiums', icon: BuildingStadiumIcon },
   { view: 'COMMUNITY', label: 'Community', description: 'Connect with fellow supporters', icon: UsersIcon },
-  { view: 'ABOUT', label: 'About', description: 'Learn about The Scrum Book', icon: InformationCircleIcon },
+  { view: 'ABOUT', label: 'About', description: 'Learn about The Turnstile', icon: InformationCircleIcon },
 ];
 
 const supporterItems: NavItem[] = [
@@ -92,7 +92,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({
             <div className="flex items-center gap-3">
               <LogoIcon className="h-10 w-10" theme={theme} />
               <div className="flex flex-col">
-                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Turnstile</span>
                 <span className="text-lg font-heading text-text-strong">Matchday Companion</span>
               </div>
             </div>

--- a/components/StatsView.tsx
+++ b/components/StatsView.tsx
@@ -83,7 +83,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
     return (
         <div className="space-y-6 text-text-strong">
              <div className="flex justify-between items-center">
-                <h1 className="text-xl font-bold">The Scrum Book</h1>
+                <h1 className="text-xl font-bold">The Turnstile</h1>
                 <button className="p-2 text-text-subtle hover:text-primary">
                     <ShareIcon className="w-6 h-6"/>
                 </button>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>The Scrum Book - Your Rugby League Companion</title>
+    <title>The Turnstile - Your Rugby League Companion</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/super-league">
   <style>

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Scrum Book",
+  "name": "The Turnstile",
    "description": "A web application for rugby league fans to track fixtures, log the games they've attended, and sync progress with Firebase when configured.",
   "requestFramePermissions": []
 }


### PR DESCRIPTION
## Summary
- replace all occurrences of "The Scrum Book" branding with "The Turnstile" across site metadata, views, and README
- update related copy including alt text, navigation labels, and community messaging to reflect the new name

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e63eb38d1c832ca26cc2e079947240