### PR TITLE
Adopt updated Turnstile color palette

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -266,7 +266,7 @@ const App = () => {
     <div className="min-h-screen font-sans text-text app-background">
       {!shouldShowLoginPrompt ? (
         <>
-          <DesktopTopBar currentView={view} setView={setView} />
+          <DesktopTopBar currentView={view} setView={setView} theme={themeMode} />
           <Header
             setView={setView}
             theme={theme}
@@ -275,7 +275,9 @@ const App = () => {
           />
           <button
             type="button"
-            className="hidden md:flex fixed top-6 right-6 z-40 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle shadow-lg transition-colors hover:text-text hover:border-border hover:bg-surface-alt/80"
+            className={`hidden md:flex fixed top-6 right-6 z-40 items-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold shadow-lg transition-colors hover:text-primary hover:border-border hover:bg-surface-alt ${
+              themeMode === 'dark' ? 'text-text' : 'text-brand-navy'
+            }`}
             onClick={() => setIsMobileNavOpen(true)}
             aria-label="Open navigation menu"
           >
@@ -303,7 +305,7 @@ const App = () => {
             onLogout={logout}
           />
           <MobileBottomBar currentView={view} setView={setView} />
-          <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface/70 backdrop-blur">
+          <footer className="hidden md:block text-center py-8 text-sm text-text-subtle/90 border-t border-border mt-4 bg-surface backdrop-blur">
             <LogoIcon className="w-12 h-12 mx-auto mb-3" theme={themeMode} />
             <p className="font-semibold text-text">The Turnstile</p>
             <p className="mt-1">Your ultimate rugby league companion. Track matches, earn badges, and connect with other fans.</p>

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 
 ```md
-# The Scrum Book
+# The Turnstile
 
-![The Scrum Book logo](public/logo.png)
+![The Turnstile logo](public/logo.png)
 
-The Scrum Book is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
+The Turnstile is a modern React + Vite application that helps rugby league fans build a personal log of matches they have attended. The MVP focuses on a single competition (the 2026 Betfred Super League), ships with a seeded fixture list, and is ready to connect to your own Firebase project for persistence.
 
 ---
 
@@ -12,7 +12,7 @@ The Scrum Book is a modern React + Vite application that helps rugby league fans
 
 - **Match Browser** — search and filter the full season fixture list and mark games you attended.
 - **Match Day dashboards** — jump to the fixtures happening soon or near you with tailored views.
-- **My Scrum Book** — track total matches, unique venues, and revisit the games you have already logged.
+- **My Turnstile** — track total matches, unique venues, and revisit the games you have already logged.
 - **Offline-friendly seed data** — local fixtures and venues power the UI until you wire up Firestore.
 
 ---

--- a/components/AboutView.tsx
+++ b/components/AboutView.tsx
@@ -34,7 +34,7 @@ interface FeatureCard {
 const highlightCards: HighlightCard[] = [
   {
     title: 'Your Digital Match Day Diary',
-    description: 'The Scrum Book is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
+    description: 'The Turnstile is your personal companion for tracking every rugby league match you attend, creating a digital diary of your support.',
     icon: SparklesIcon,
     accent: 'from-primary/80 to-secondary/70',
     footer: 'Never forget a match day memory.',
@@ -114,19 +114,19 @@ interface AboutViewProps {
 export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
   return (
     <div className="space-y-12">
-      <section className="relative overflow-hidden rounded-3xl border border-white/60 bg-surface shadow-card dark:border-white/10">
+      <section className="relative overflow-hidden rounded-3xl border border-border/60 bg-surface shadow-card">
         <div className="pointer-events-none absolute inset-0 bg-gradient-to-br from-primary/10 via-accent/10 to-secondary/10" />
         <div className="relative grid gap-10 px-6 py-12 md:grid-cols-[1.1fr,0.9fr] md:px-12">
           <div>
-            <div className="mb-6 flex items-center gap-3 text-primary">
+            <div className="mb-6 flex items-center gap-3 text-text-strong">
               <LogoIcon className="h-10 w-10" theme={theme} />
-              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+              <span className="text-sm font-semibold uppercase tracking-[0.3em] text-text-subtle">The Turnstile</span>
             </div>
             <h1 className="text-4xl font-bold text-text-strong md:text-5xl">
               Your Ultimate Rugby League Companion
             </h1>
             <p className="mt-5 max-w-2xl text-lg text-text">
-              The Scrum Book is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.
+              The Turnstile is a dedicated space for rugby league fans to record their match-going history, celebrate their support, and connect with a community of fellow enthusiasts.
             </p>
             <div className="mt-8 flex flex-wrap gap-4 text-sm">
               <div className="flex items-center gap-2 rounded-full bg-primary/10 px-4 py-2 font-semibold text-primary">
@@ -148,21 +148,21 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
             <div className="relative rounded-2xl border border-border/70 bg-gradient-to-br from-surface-alt via-surface to-surface-alt p-6 shadow-card">
               <h2 className="text-sm font-semibold uppercase tracking-[0.2em] text-text-subtle">Key Features</h2>
               <ul className="mt-4 space-y-3 text-sm text-text">
-                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface p-3">
                   <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-primary/10 font-semibold text-primary">1</span>
                   <div>
                     <p className="font-semibold text-text-strong">Personal Match Log</p>
                     <p>Build a comprehensive history of every game you've seen live.</p>
                   </div>
                 </li>
-                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface p-3">
                   <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-secondary/10 font-semibold text-secondary">2</span>
                   <div>
                     <p className="font-semibold text-text-strong">Fan Statistics</p>
                     <p>Get insights into your support with personalized stats and data.</p>
                   </div>
                 </li>
-                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface/80 p-3">
+                <li className="flex items-start gap-3 rounded-xl border border-border/70 bg-surface p-3">
                   <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-accent/10 font-semibold text-accent">3</span>
                   <div>
                     <p className="font-semibold text-text-strong">Community Hub</p>
@@ -202,7 +202,7 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
         {featureColumns.map((column) => {
           const Icon = column.icon;
           return (
-            <div key={column.title} className="rounded-3xl border border-border/70 bg-surface-alt/60 p-6 shadow-card">
+            <div key={column.title} className="rounded-3xl border border-border/70 bg-surface-alt p-6 shadow-card">
               <div className="flex items-center gap-3">
                 <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-primary/10 text-primary">
                   <Icon className="h-6 w-6" />
@@ -231,7 +231,7 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
           {featureCards.map((feature) => {
             const Icon = feature.icon;
             return (
-              <div key={feature.title} className="rounded-2xl border border-border/70 bg-surface-alt/60 p-5">
+              <div key={feature.title} className="rounded-2xl border border-border/70 bg-surface-alt p-5">
                 <div className="flex items-center gap-3">
                   <div className="inline-flex h-10 w-10 items-center justify-center rounded-xl bg-secondary/10 text-secondary">
                     <Icon className="h-5 w-5" />
@@ -250,7 +250,7 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
         <h2 className="text-2xl font-bold text-text-strong">Get Started in Minutes</h2>
         <ul className="mt-4 grid gap-4 text-sm text-text md:grid-cols-2">
           {getStartedSteps.map((item) => (
-            <li key={item} className="flex items-start gap-3 rounded-2xl border border-primary/20 bg-surface/70 p-4 shadow-sm">
+            <li key={item} className="flex items-start gap-3 rounded-2xl border border-primary/20 bg-surface p-4 shadow-sm">
               <div className="mt-1 h-6 w-6 rounded-full bg-primary/15 text-center text-sm font-semibold leading-6 text-primary">✓</div>
               <span>{item}</span>
             </li>
@@ -258,10 +258,10 @@ export const AboutView: React.FC<AboutViewProps> = ({ theme }) => {
         </ul>
       </section>
 
-      <section className="rounded-3xl border border-border/80 bg-surface-alt/80 p-8 text-center shadow-card">
-        <h2 className="text-2xl font-bold text-text-strong">Join The Scrum Book Community</h2>
+      <section className="rounded-3xl border border-border/80 bg-surface-alt p-8 text-center shadow-card">
+        <h2 className="text-2xl font-bold text-text-strong">Join The Turnstile Community</h2>
         <p className="mt-2 text-text">
-          Start building your fan legacy today. The Scrum Book is your home for all your rugby league memories and connections.
+          Start building your fan legacy today. The Turnstile is your home for all your rugby league memories and connections.
         </p>
         <p className="mt-4 text-sm font-medium uppercase tracking-[0.2em] text-text-subtle">
           Track. Share. Celebrate.

--- a/components/DataUploader.tsx
+++ b/components/DataUploader.tsx
@@ -13,7 +13,7 @@ export const DataUploader: React.FC = () => {
       </div>
 
       <p className="text-text-subtle mb-6">
-        The Scrum Book runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
+        The Turnstile runs in offline mode by default. Configure Firebase before attempting to upload the seeded data set.
       </p>
 
       <div className="rounded-md border border-warning/30 bg-warning/10 p-4 text-warning flex items-center gap-3">

--- a/components/DesktopTopBar.tsx
+++ b/components/DesktopTopBar.tsx
@@ -6,9 +6,10 @@ import { ArrowLeftIcon } from './Icons';
 interface DesktopTopBarProps {
   currentView: View;
   setView: (view: View) => void;
+  theme: 'light' | 'dark';
 }
 
-export const DesktopTopBar: React.FC<DesktopTopBarProps> = ({ currentView, setView }) => {
+export const DesktopTopBar: React.FC<DesktopTopBarProps> = ({ currentView, setView, theme }) => {
   const handleBack = () => {
     if (window.history.length > 1) {
       window.history.back();
@@ -17,13 +18,20 @@ export const DesktopTopBar: React.FC<DesktopTopBarProps> = ({ currentView, setVi
     }
   };
 
+  const isDarkMode = theme === 'dark';
+  const inactiveNavClasses = isDarkMode
+    ? 'text-text hover:text-primary hover:bg-surface-alt border border-transparent'
+    : 'text-brand-navy hover:text-primary hover:bg-surface-alt border border-transparent';
+
   return (
-    <nav className="hidden md:flex fixed inset-x-0 top-0 z-30 border-b border-border/70 bg-surface/80 backdrop-blur">
+    <nav className="hidden md:flex fixed inset-x-0 top-0 z-30 border-b border-border/70 bg-surface shadow-md backdrop-blur">
       <div className="mx-auto flex w-full max-w-6xl items-center gap-4 px-6 py-3">
         <button
           type="button"
           onClick={handleBack}
-          className="flex items-center gap-2 rounded-full border border-border/70 bg-surface-alt/70 px-3 py-2 text-sm font-semibold text-text-subtle transition-colors hover:border-border hover:text-text"
+          className={`flex items-center gap-2 rounded-full border border-border/70 bg-surface-alt px-3 py-2 text-sm font-semibold transition-colors hover:border-border hover:text-primary ${
+            isDarkMode ? 'text-text' : 'text-brand-navy'
+          }`}
           aria-label="Go back"
         >
           <ArrowLeftIcon className="h-4 w-4" />
@@ -40,8 +48,8 @@ export const DesktopTopBar: React.FC<DesktopTopBarProps> = ({ currentView, setVi
                   onClick={() => setView(view)}
                   className={`rounded-full px-4 py-2 text-sm font-semibold transition-colors ${
                     isActive
-                      ? 'bg-primary/15 text-primary border border-primary/40 shadow-sm'
-                      : 'text-text-subtle hover:text-text hover:bg-surface-alt/80 border border-transparent'
+                      ? 'bg-primary/20 text-primary border border-primary/40 shadow-sm'
+                      : inactiveNavClasses
                   }`}
                   aria-current={isActive ? 'page' : undefined}
                 >

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -11,15 +11,15 @@
   border-radius: 999px;
   border: none;
   background: rgba(15, 23, 42, 0.88);
-  color: #ffffff;
-  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.75);
+  color: #F8FAFC;
+  box-shadow: 0 18px 32px -18px rgba(11, 16, 32, 0.75);
   transition: transform 0.18s ease, box-shadow 0.18s ease;
   cursor: pointer;
 }
 
 .backButton:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 36px -18px rgba(15, 23, 42, 0.85);
+  box-shadow: 0 20px 36px -18px rgba(11, 16, 32, 0.85);
 }
 
 .backIcon {
@@ -59,15 +59,15 @@
   border-radius: 999px;
   border: none;
   background: rgba(15, 23, 42, 0.88);
-  color: #ffffff;
-  box-shadow: 0 18px 32px -18px rgba(15, 23, 42, 0.75);
+  color: #F8FAFC;
+  box-shadow: 0 18px 32px -18px rgba(11, 16, 32, 0.75);
   transition: transform 0.18s ease, box-shadow 0.18s ease;
   cursor: pointer;
 }
 
 .menuButton:hover {
   transform: translateY(-2px);
-  box-shadow: 0 20px 36px -18px rgba(15, 23, 42, 0.85);
+  box-shadow: 0 20px 36px -18px rgba(11, 16, 32, 0.85);
 }
 
 .menuIcon {
@@ -78,6 +78,6 @@
 .backButton:focus-visible,
 .logoButton:focus-visible,
 .menuButton:focus-visible {
-  outline: 3px solid rgba(59, 130, 246, 0.8);
+  outline: 3px solid rgba(37, 99, 235, 0.75);
   outline-offset: 3px;
 }

--- a/components/Icons.tsx
+++ b/components/Icons.tsx
@@ -23,7 +23,7 @@ export const LogoIcon: React.FC<LogoIconProps> = ({ className, theme = 'light', 
   return (
     <img
       src={resolvedSrc}
-      alt={alt ?? 'The Scrum Book logo'}
+      alt={alt ?? 'The Turnstile logo'}
       className={className}
       loading="lazy"
       style={{

--- a/components/LeagueTableView.tsx
+++ b/components/LeagueTableView.tsx
@@ -92,7 +92,7 @@ export const LeagueTableView: React.FC = () => {
                             {table.map(standing => (
                                 <tr 
                                     key={standing.teamId} 
-                                    className="hover:bg-surface-alt even:bg-surface-alt/50 transition-colors"
+                                    className="hover:bg-surface-alt even:bg-surface-alt transition-colors"
                                     style={{ borderLeft: `4px solid ${TEAM_BRANDING[standing.teamId]?.bg || 'transparent'}` }}
                                 >
                                     <td className="px-4 h-12 font-bold text-center text-text-strong">{standing.rank}</td>

--- a/components/LoginPromptView.tsx
+++ b/components/LoginPromptView.tsx
@@ -29,16 +29,16 @@ const getErrorMessage = (error: unknown, fallback: string) =>
 const getFeedbackClasses = (mode: AuthMode, type: 'success' | 'error') => {
   const palette = {
     login: {
-      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
-      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+      success: 'bg-[color:rgba(6,182,212,0.16)] text-white border-[color:rgba(6,182,212,0.45)]',
+      error: 'bg-[color:rgba(239,68,68,0.18)] text-white border-[color:rgba(239,68,68,0.5)]',
     },
     signup: {
-      success: 'bg-emerald-50 text-emerald-600 border-emerald-200',
-      error: 'bg-rose-50 text-rose-600 border-rose-200',
+      success: 'bg-[color:rgba(6,182,212,0.12)] text-brand-navy border-[color:rgba(6,182,212,0.35)]',
+      error: 'bg-[color:rgba(239,68,68,0.12)] text-brand-navy border-[color:rgba(239,68,68,0.35)]',
     },
     forgot: {
-      success: 'bg-emerald-400/10 text-emerald-100 border-emerald-300/60',
-      error: 'bg-rose-500/10 text-rose-100 border-rose-400/60',
+      success: 'bg-[color:rgba(6,182,212,0.16)] text-white border-[color:rgba(6,182,212,0.45)]',
+      error: 'bg-[color:rgba(239,68,68,0.18)] text-white border-[color:rgba(239,68,68,0.5)]',
     },
   } as const;
 
@@ -217,9 +217,9 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
 
   const renderLoginCard = () => (
     <div className="mx-auto w-full max-w-[420px]">
-      <div className="relative overflow-hidden rounded-[36px] bg-[#031a29] px-8 pb-12 pt-14 text-white shadow-[0px_25px_60px_rgba(3,26,41,0.55)]">
+      <div className="relative overflow-hidden rounded-[36px] bg-[color:var(--clr-surface-0)] px-8 pb-12 pt-14 text-white shadow-[0px_25px_60px_rgba(11,16,32,0.55)]">
         <div className="pointer-events-none absolute inset-0">
-          <div className="absolute -top-24 -right-20 h-64 w-64 rounded-full bg-[#103852] opacity-50 blur-3xl" />
+          <div className="absolute -top-24 -right-20 h-64 w-64 rounded-full bg-[rgba(30,58,138,0.5)] blur-3xl" />
           <LogoIcon
             className="absolute -top-28 left-1/2 h-60 w-60 -translate-x-1/2 opacity-[0.08]"
             theme="dark"
@@ -228,10 +228,10 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
         </div>
 
         <div className="relative flex flex-col items-center text-center">
-          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0px_15px_35px_rgba(3,19,31,0.45)]">
+          <div className="flex h-20 w-20 items-center justify-center rounded-full border border-white/20 bg-white/5 shadow-[0px_15px_35px_rgba(11,16,32,0.45)]">
             <LogoIcon className="h-12 w-12 drop-shadow" theme={theme} />
           </div>
-          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Scrum Book</p>
+          <p className="mt-6 text-xs font-semibold uppercase tracking-[0.55em] text-white/70">The Turnstile</p>
           <h1 className="mt-3 text-3xl font-heading font-bold leading-snug">Rugby League Check In</h1>
           <p className="mt-3 max-w-xs text-sm text-white/60">
             Sign in to manage your matchdays, track your stats, and stay connected with the rugby league community.
@@ -289,12 +289,12 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
 
           <button
             type="submit"
-            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#032130] shadow-[0px_12px_35px_rgba(3,19,31,0.45)] transition hover:bg-white/90 disabled:opacity-70"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-brand-navy shadow-[0px_12px_35px_rgba(11,16,32,0.45)] transition hover:bg-white/90 disabled:opacity-70"
             disabled={busy('login')}
           >
             {busy('login') ? (
               <>
-                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#032130]" />
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-brand-navy" />
                 Logging in…
               </>
             ) : (
@@ -340,8 +340,8 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
   );
 
   const renderSignupCard = () => (
-    <div className="mx-auto w-full max-w-[480px] overflow-hidden rounded-[36px] bg-white shadow-[0px_25px_60px_rgba(3,26,41,0.35)]">
-      <div className="relative bg-[#031d2c] px-10 pb-12 pt-16 text-white">
+    <div className="mx-auto w-full max-w-[480px] overflow-hidden rounded-[36px] bg-white shadow-[0px_25px_60px_rgba(11,16,32,0.35)]">
+      <div className="relative bg-[color:var(--clr-surface-1)] px-10 pb-12 pt-16 text-white">
         <LogoIcon className="absolute -right-14 -top-14 h-40 w-40 opacity-[0.08]" theme="dark" aria-hidden />
         <p className="text-lg font-semibold uppercase tracking-[0.35em] text-white/60">Let&apos;s</p>
         <h2 className="mt-3 text-4xl font-heading leading-[1.15]">
@@ -356,79 +356,79 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
 
       <form className="bg-white px-10 py-10" onSubmit={handleSignup}>
         <div className="space-y-5">
-          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
-            <UserCircleIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+          <div className="flex items-center gap-3 rounded-full border border-[rgba(30,58,138,0.14)] bg-[color:var(--clr-surface)] px-5 py-3 transition focus-within:border-brand-navy">
+            <UserCircleIcon className="h-5 w-5 text-brand-navy/60" />
             <input
               type="text"
               placeholder="Full Name"
               autoComplete="name"
-              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              className="w-full bg-transparent text-base text-brand-navy placeholder:text-brand-navy/40 focus:outline-none"
               value={signupForm.name}
               onChange={(event) => setSignupForm((prev) => ({ ...prev, name: event.target.value }))}
               disabled={busy('signup')}
             />
           </div>
 
-          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
-            <EnvelopeIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+          <div className="flex items-center gap-3 rounded-full border border-[rgba(30,58,138,0.14)] bg-[color:var(--clr-surface)] px-5 py-3 transition focus-within:border-brand-navy">
+            <EnvelopeIcon className="h-5 w-5 text-brand-navy/60" />
             <input
               type="email"
               placeholder="Email Address"
               autoComplete="email"
-              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              className="w-full bg-transparent text-base text-brand-navy placeholder:text-brand-navy/40 focus:outline-none"
               value={signupForm.email}
               onChange={(event) => setSignupForm((prev) => ({ ...prev, email: event.target.value }))}
               disabled={busy('signup')}
             />
           </div>
 
-          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
-            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+          <div className="flex items-center gap-3 rounded-full border border-[rgba(30,58,138,0.14)] bg-[color:var(--clr-surface)] px-5 py-3 transition focus-within:border-brand-navy">
+            <LockClosedIcon className="h-5 w-5 text-brand-navy/60" />
             <input
               type="password"
               placeholder="Password"
               autoComplete="new-password"
-              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              className="w-full bg-transparent text-base text-brand-navy placeholder:text-brand-navy/40 focus:outline-none"
               value={signupForm.password}
               onChange={(event) => setSignupForm((prev) => ({ ...prev, password: event.target.value }))}
               disabled={busy('signup')}
             />
           </div>
 
-          <div className="flex items-center gap-3 rounded-full border border-[#0b2a2f1f] bg-[#f5f7fa] px-5 py-3 transition focus-within:border-[#0B2A2F]">
-            <LockClosedIcon className="h-5 w-5 text-[#0B2A2F]/60" />
+          <div className="flex items-center gap-3 rounded-full border border-[rgba(30,58,138,0.14)] bg-[color:var(--clr-surface)] px-5 py-3 transition focus-within:border-brand-navy">
+            <LockClosedIcon className="h-5 w-5 text-brand-navy/60" />
             <input
               type="password"
               placeholder="Retype Password"
               autoComplete="new-password"
-              className="w-full bg-transparent text-base text-[#0B2A2F] placeholder:text-[#0B2A2F]/40 focus:outline-none"
+              className="w-full bg-transparent text-base text-brand-navy placeholder:text-brand-navy/40 focus:outline-none"
               value={signupForm.confirmPassword}
               onChange={(event) => setSignupForm((prev) => ({ ...prev, confirmPassword: event.target.value }))}
               disabled={busy('signup')}
             />
           </div>
 
-          <label className="flex items-center gap-3 text-sm text-[#0B2A2F]/70">
+          <label className="flex items-center gap-3 text-sm text-brand-navy/70">
             <input
               type="checkbox"
-              className="h-4 w-4 rounded border border-[#0B2A2F]/30 text-[#0B2A2F] focus:ring-[#0B2A2F]"
+              className="h-4 w-4 rounded border border-brand-navy/30 text-brand-navy focus:ring-brand-navy"
               checked={signupForm.acceptsTerms}
               onChange={(event) => setSignupForm((prev) => ({ ...prev, acceptsTerms: event.target.checked }))}
               disabled={busy('signup')}
             />
             <span>
-              I agree to the <span className="font-semibold text-[#0B2A2F]">Terms &amp; Privacy</span>
+              I agree to the <span className="font-semibold text-brand-navy">Terms &amp; Privacy</span>
             </span>
           </label>
 
           <button
             type="submit"
-            className="flex w-full items-center justify-center gap-2 rounded-full bg-[#d9e4ec] py-3 text-base font-semibold text-[#0B2A2F] transition hover:bg-[#c8d7e2] disabled:opacity-60"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-brand-navy/10 py-3 text-base font-semibold text-brand-navy transition hover:bg-brand-navy/20 disabled:opacity-60"
             disabled={busy('signup')}
           >
             {busy('signup') ? (
               <>
-                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#0B2A2F]" />
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-brand-navy" />
                 Signing you up…
               </>
             ) : (
@@ -438,11 +438,11 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
 
           {renderFeedback()}
 
-          <p className="mt-6 text-center text-sm text-[#0B2A2F]/70">
+          <p className="mt-6 text-center text-sm text-brand-navy/70">
             Have an account?
             <button
               type="button"
-              className="ml-1 font-semibold text-[#0B2A2F] underline decoration-dotted underline-offset-4"
+              className="ml-1 font-semibold text-brand-navy underline decoration-dotted underline-offset-4"
               onClick={() => setMode('login')}
             >
               Sign In
@@ -454,16 +454,16 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
   );
 
   const renderForgotCard = () => (
-    <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-[36px] bg-white text-[#0B2A2F] shadow-[0px_25px_60px_rgba(3,26,41,0.35)]">
+    <div className="mx-auto w-full max-w-[420px] overflow-hidden rounded-[36px] bg-white text-brand-navy shadow-[0px_25px_60px_rgba(11,16,32,0.35)]">
       <div className="px-10 pb-8 pt-12 text-center">
-        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-[#0B2A2F]/10 text-[#0B2A2F]">
+        <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-brand-navy/10 text-brand-navy">
           <LockClosedIcon className="h-7 w-7" />
         </div>
-        <h2 className="text-3xl font-heading font-semibold text-[#133347]">Forgot Password?</h2>
-        <p className="mt-3 text-sm text-[#375566]">No worries, we&apos;ll send you reset instructions.</p>
+        <h2 className="text-3xl font-heading font-semibold text-brand-navy">Forgot Password?</h2>
+        <p className="mt-3 text-sm text-brand-navy/80">No worries, we&apos;ll send you reset instructions.</p>
       </div>
 
-      <div className="relative bg-[#031d2c] px-10 pb-10 pt-10 text-white">
+      <div className="relative bg-[color:var(--clr-surface-1)] px-10 pb-10 pt-10 text-white">
         <LogoIcon className="pointer-events-none absolute -bottom-10 right-8 h-28 w-28 opacity-[0.08]" theme="dark" aria-hidden />
         <form className="space-y-6" onSubmit={handleForgotPassword}>
           <div>
@@ -487,12 +487,12 @@ export const LoginPromptView: React.FC<LoginPromptViewProps> = ({
 
           <button
             type="submit"
-            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-[#031d2c] shadow-[0px_10px_40px_rgba(0,0,0,0.35)] transition hover:bg-white/95 disabled:opacity-70"
+            className="flex w-full items-center justify-center gap-2 rounded-full bg-white py-3 text-base font-semibold text-brand-navy shadow-[0px_10px_40px_rgba(11,16,32,0.35)] transition hover:bg-white/95 disabled:opacity-70"
             disabled={busy('forgot')}
           >
             {busy('forgot') ? (
               <>
-                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-[#031d2c]" />
+                <MiniSpinnerIcon className="h-5 w-5 animate-spin text-brand-navy" />
                 Sending reset link…
               </>
             ) : (

--- a/components/MobileBottomBar.tsx
+++ b/components/MobileBottomBar.tsx
@@ -9,7 +9,7 @@ interface MobileBottomBarProps {
 
 export const MobileBottomBar: React.FC<MobileBottomBarProps> = ({ currentView, setView }) => {
   return (
-    <nav className="md:hidden fixed inset-x-0 bottom-0 z-20 border-t border-border/70 bg-surface/95 backdrop-blur">
+    <nav className="md:hidden fixed inset-x-0 bottom-0 z-20 border-t border-border/70 bg-surface backdrop-blur">
       <div className="mx-auto w-full max-w-2xl px-1.5 pb-[calc(env(safe-area-inset-bottom)+6px)] pt-1">
         {/* Changed from a grid to a flexbox for a single row layout */}
         <div className="flex items-center justify-around">
@@ -24,7 +24,7 @@ export const MobileBottomBar: React.FC<MobileBottomBarProps> = ({ currentView, s
                 className={`flex h-12 w-16 items-center justify-center rounded-lg transition-colors ${
                   isActive
                     ? 'bg-primary/20 text-primary'
-                    : 'text-text-subtle hover:text-text hover:bg-surface-alt/80'
+                    : 'text-text-subtle hover:text-text hover:bg-surface-alt'
                 }`}
                 aria-current={isActive ? 'page' : undefined}
                 aria-label={label}

--- a/components/MobileNav.tsx
+++ b/components/MobileNav.tsx
@@ -42,7 +42,7 @@ const primaryItems: NavItem[] = [
   { view: 'LEAGUE_TABLE', label: 'League Table', description: 'Track club standings', icon: TableCellsIcon },
   { view: 'GROUNDS', label: 'Grounds', description: 'Explore Super League stadiums', icon: BuildingStadiumIcon },
   { view: 'COMMUNITY', label: 'Community', description: 'Connect with fellow supporters', icon: UsersIcon },
-  { view: 'ABOUT', label: 'About', description: 'Learn about The Scrum Book', icon: InformationCircleIcon },
+  { view: 'ABOUT', label: 'About', description: 'Learn about The Turnstile', icon: InformationCircleIcon },
 ];
 
 const supporterItems: NavItem[] = [
@@ -71,6 +71,16 @@ export const MobileNav: React.FC<MobileNavProps> = ({
     onClose();
   };
 
+  const isDarkMode = theme === 'dark';
+  const inactiveButtonClasses = isDarkMode
+    ? 'border-border/60 bg-surface text-text hover:border-primary/50 hover:bg-surface-alt'
+    : 'border-border/50 bg-surface text-brand-navy hover:border-primary/50 hover:bg-surface-alt';
+  const inactiveIconClasses = isDarkMode
+    ? 'border-border/60 bg-surface-alt text-text'
+    : 'border-border/50 bg-surface-alt text-brand-navy';
+  const inactiveLabelClass = isDarkMode ? 'text-text' : 'text-brand-navy';
+  const logoutTextClass = isDarkMode ? 'text-text' : 'text-brand-navy';
+
   return (
     <>
       <div
@@ -88,11 +98,11 @@ export const MobileNav: React.FC<MobileNavProps> = ({
         aria-label="Mobile navigation"
       >
         <div className="flex h-full flex-col">
-          <div className="flex items-center justify-between px-5 py-5 border-b border-border/70 bg-surface-alt/60 backdrop-blur">
+          <div className="flex items-center justify-between px-5 py-5 border-b border-border/70 bg-surface-alt backdrop-blur">
             <div className="flex items-center gap-3">
               <LogoIcon className="h-10 w-10" theme={theme} />
               <div className="flex flex-col">
-                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Scrum Book</span>
+                <span className="text-xs font-semibold uppercase tracking-[0.3em] text-text-subtle">The Turnstile</span>
                 <span className="text-lg font-heading text-text-strong">Matchday Companion</span>
               </div>
             </div>
@@ -116,8 +126,8 @@ export const MobileNav: React.FC<MobileNavProps> = ({
                         onClick={() => handleNavigate(view)}
                         className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
                           isActive
-                            ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
-                            : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                            ? 'border-primary/50 bg-primary/20 text-primary shadow-card'
+                            : inactiveButtonClasses
                         }`}
                       >
                         <div className="flex items-center gap-3">
@@ -125,13 +135,13 @@ export const MobileNav: React.FC<MobileNavProps> = ({
                             className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
                               isActive
                                 ? 'border-primary/40 bg-primary/20 text-primary'
-                                : 'border-border/70 bg-surface text-text-subtle'
+                                : inactiveIconClasses
                             }`}
                           >
                             <Icon className="h-5 w-5" />
                           </span>
                           <div>
-                            <p className="font-heading text-lg text-text-strong">{label}</p>
+                            <p className={`font-heading text-lg ${isActive ? 'text-primary' : inactiveLabelClass}`}>{label}</p>
                             {description && <p className="text-xs text-text-subtle">{description}</p>}
                           </div>
                         </div>
@@ -154,10 +164,10 @@ export const MobileNav: React.FC<MobileNavProps> = ({
                         onClick={() => !disabled && handleNavigate(view)}
                         className={`w-full rounded-xl border px-4 py-3 text-left transition-colors duration-200 ${
                           disabled
-                            ? 'cursor-not-allowed border-border/40 bg-surface-alt/30 text-text-subtle'
+                            ? 'cursor-not-allowed border-border/40 bg-surface-alt text-text-subtle'
                             : isActive
-                              ? 'border-primary/50 bg-primary/15 text-primary shadow-card'
-                              : 'border-transparent bg-surface-alt/50 text-text hover:border-border/80 hover:bg-surface'
+                              ? 'border-primary/50 bg-primary/20 text-primary shadow-card'
+                              : inactiveButtonClasses
                         }`}
                         aria-disabled={disabled}
                       >
@@ -166,13 +176,13 @@ export const MobileNav: React.FC<MobileNavProps> = ({
                             className={`flex h-10 w-10 items-center justify-center rounded-lg border ${
                               isActive
                                 ? 'border-primary/40 bg-primary/20 text-primary'
-                                : 'border-border/70 bg-surface text-text-subtle'
+                                : inactiveIconClasses
                             }`}
                           >
                             <Icon className="h-5 w-5" />
                           </span>
                           <div>
-                            <p className="font-heading text-lg text-text-strong">{label}</p>
+                            <p className={`font-heading text-lg ${isActive ? 'text-primary' : inactiveLabelClass}`}>{label}</p>
                             {description && <p className="text-xs text-text-subtle">{description}</p>}
                             {disabled && (
                               <p className="text-[11px] font-medium text-danger mt-1">Login required</p>
@@ -186,7 +196,7 @@ export const MobileNav: React.FC<MobileNavProps> = ({
               </ul>
             </div>
 
-            <div className="rounded-xl border border-border/60 bg-surface-alt/60 px-4 py-4 text-sm text-text-subtle">
+            <div className="rounded-xl border border-border/60 bg-surface-alt px-4 py-4 text-sm text-text-subtle">
               <p className="font-heading text-text-strong text-lg">Matchday Tip</p>
               <p className="mt-2">
                 Keep your supporter log up to date to unlock new badges and season-long stats. Tap “My Matches” after every game you attend.
@@ -194,11 +204,11 @@ export const MobileNav: React.FC<MobileNavProps> = ({
             </div>
           </div>
           {currentUser && (
-            <div className="border-t border-border/70 bg-surface/80 px-5 py-4">
+            <div className="border-t border-border/70 bg-surface px-5 py-4">
               <button
                 type="button"
                 onClick={handleLogout}
-                className="w-full inline-flex items-center justify-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold text-text-subtle transition-colors hover:text-text hover:border-border hover:bg-surface-alt/70"
+                className={`w-full inline-flex items-center justify-center gap-2 rounded-full border border-border/70 bg-surface px-4 py-2 text-sm font-semibold transition-colors hover:text-primary hover:border-border hover:bg-surface-alt ${logoutTextClass}`}
               >
                 <ArrowLeftOnRectangleIcon className="h-5 w-5" />
                 <span>Logout</span>

--- a/components/ProfileView.module.css
+++ b/components/ProfileView.module.css
@@ -1,14 +1,14 @@
 .profilePage {
-  --hero-overlay: linear-gradient(135deg, rgba(17, 46, 114, 0.96), rgba(20, 31, 67, 0.92));
-  --hero-highlight: rgba(30, 139, 255, 0.85);
+  --hero-overlay: linear-gradient(135deg, rgba(30, 58, 138, 0.92), rgba(15, 23, 42, 0.9));
+  --hero-highlight: rgba(245, 158, 11, 0.85);
   --card-bg: var(--clr-surface);
-  --card-border: rgba(15, 23, 42, 0.08);
-  --card-shadow: 0 32px 60px -30px rgba(15, 23, 42, 0.55);
+  --card-border: rgba(51, 65, 85, 0.18);
+  --card-shadow: 0 32px 60px -30px rgba(11, 16, 32, 0.55);
   --text-strong: var(--clr-text-strong);
   --text-subtle: var(--clr-text-subtle);
 
   min-height: 100%;
-  background: linear-gradient(180deg, rgba(7, 11, 23, 0.15) 0%, rgba(7, 11, 23, 0) 30%), #f5f7fb;
+  background: linear-gradient(180deg, rgba(15, 23, 42, 0.08) 0%, rgba(15, 23, 42, 0) 30%), var(--clr-surface);
   color: var(--text-strong);
 }
 
@@ -16,7 +16,7 @@
   position: relative;
   padding: clamp(2.5rem, 6vw, 3.75rem) clamp(1.5rem, 5vw, 3rem) clamp(7rem, 12vw, 9rem);
   overflow: hidden;
-  color: #ecf5ff;
+  color: #F8FAFC;
   background: var(--hero-overlay);
   border-bottom-left-radius: clamp(3rem, 10vw, 5rem);
 }
@@ -79,15 +79,15 @@
   justify-content: center;
   background: var(--hero-highlight);
   border: 3px solid rgba(255, 255, 255, 0.5);
-  box-shadow: 0 18px 30px -12px rgba(30, 139, 255, 0.9);
-  color: #fff;
+  box-shadow: 0 18px 30px -12px rgba(37, 99, 235, 0.6);
+  color: #F8FAFC;
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .avatarEdit:hover {
   transform: translateY(-2px) scale(1.02);
-  box-shadow: 0 24px 40px -16px rgba(30, 139, 255, 0.9);
+  box-shadow: 0 24px 40px -16px rgba(37, 99, 235, 0.65);
 }
 
 .avatarEdit svg {
@@ -138,8 +138,8 @@
   border-radius: 16px;
   padding: 0.65rem 1.5rem;
   font-weight: 700;
-  background: #fff;
-  color: #0a1e4a;
+  background: var(--clr-surface);
+  color: var(--clr-primary);
   cursor: pointer;
 }
 
@@ -172,7 +172,7 @@
   gap: 0.4rem;
   padding: 0.4rem 1.1rem;
   border-radius: 999px;
-  background: rgba(12, 28, 74, 0.55);
+  background: rgba(30, 58, 138, 0.55);
   backdrop-filter: blur(4px);
   font-size: 0.95rem;
   font-weight: 600;
@@ -182,7 +182,7 @@
 .tagline svg {
   width: 1rem;
   height: 1rem;
-  color: rgba(255, 199, 78, 1);
+  color: #F59E0B;
 }
 
 .teamBadge {
@@ -193,7 +193,7 @@
   padding: 0.55rem 1.1rem;
   border-radius: 14px;
   background: rgba(255, 255, 255, 0.18);
-  color: #fff;
+  color: #F8FAFC;
   font-weight: 600;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
 }
@@ -242,7 +242,7 @@
   margin: 0;
   font-size: clamp(1.9rem, 5vw, 2.4rem);
   font-weight: 800;
-  color: #fff;
+  color: #F8FAFC;
 }
 
 .mainContent {

--- a/components/ProfileView.tsx
+++ b/components/ProfileView.tsx
@@ -749,7 +749,7 @@ export const ProfileView: React.FC<ProfileViewProps> = ({
 
               {isCustomisingLayout && (
                 <div className="pointer-events-none absolute inset-x-4 top-4 flex flex-wrap justify-end gap-2 text-xs font-semibold uppercase tracking-wide text-text-subtle">
-                  <span className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-surface-alt/90 px-3 py-1 shadow-sm">
+                  <span className="pointer-events-auto inline-flex items-center gap-2 rounded-full bg-surface-alt px-3 py-1 shadow-sm">
                     {getTileTypeHint(definition)}
                   </span>
                   <div className="pointer-events-auto flex items-center gap-2">

--- a/components/StatsView.tsx
+++ b/components/StatsView.tsx
@@ -83,7 +83,7 @@ export const StatsView: React.FC<StatsViewProps> = ({ attendedMatches, user }) =
     return (
         <div className="space-y-6 text-text-strong">
              <div className="flex justify-between items-center">
-                <h1 className="text-xl font-bold">The Scrum Book</h1>
+                <h1 className="text-xl font-bold">The Turnstile</h1>
                 <button className="p-2 text-text-subtle hover:text-primary">
                     <ShareIcon className="w-6 h-6"/>
                 </button>

--- a/index.html
+++ b/index.html
@@ -4,51 +4,58 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/logo.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>The Scrum Book - Your Rugby League Companion</title>
+    <title>The Turnstile - Your Rugby League Companion</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <link rel="stylesheet" href="https://fonts.cdnfonts.com/css/super-league">
   <style>
       :root {
         color-scheme: light;
-        --clr-primary: #E21836;
-        --clr-primary-bright: #FF4D6D;
-        --clr-secondary: #FFD447;
-        --clr-accent: #0074FF;
-        --clr-danger: #E21836;
-        --clr-warning: #FFD447;
-        --clr-info: #0052CC;
-        --clr-success: #00A86B;
-        --clr-text-strong: #FFFFFF;
-        --clr-text: #F3F4F6;
-        --clr-text-subtle: #CDD2D9;
-        --clr-border: #404040;
-        --clr-surface: #1F2023;
-        --clr-surface-alt: #161719;
-        --gradient-1: linear-gradient(140deg, rgba(226, 24, 54, 0.15), rgba(0, 82, 204, 0.1));
-        --gradient-2: radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.1), transparent 55%);
-        --gradient-3: radial-gradient(circle at 80% 0%, rgba(226, 24, 54, 0.12), transparent 45%);
+        --clr-primary: #1E3A8A;
+        --clr-primary-600: #2563EB;
+        --clr-secondary: #2563EB;
+        --clr-accent: #F59E0B;
+        --clr-danger: #EF4444;
+        --clr-warning: #F59E0B;
+        --clr-info: #2563EB;
+        --clr-success: #06B6D4;
+        --clr-text-strong: #0B1020;
+        --clr-text: #1E3A8A;
+        --clr-text-subtle: #334155;
+        --clr-brand-navy: #1E3A8A;
+        --clr-border: #334155;
+        --clr-surface-0: #0B1020;
+        --clr-surface-1: #0F172A;
+        --clr-surface-2: #111827;
+        --clr-surface: #F8FAFC;
+        --clr-surface-alt: #E2E8F0;
+        --gradient-1: linear-gradient(140deg, rgba(30, 58, 138, 0.12), rgba(37, 99, 235, 0.08));
+        --gradient-2: radial-gradient(circle at 18% 20%, rgba(245, 158, 11, 0.16), transparent 56%);
+        --gradient-3: radial-gradient(circle at 78% -10%, rgba(30, 58, 138, 0.14), transparent 48%);
         --font-heading: "Super League", "Inter", sans-serif;
-        --app-background-image: url('/background.png'); 
+        --app-background-image: url('/background.png');
+        --app-background-overlay: linear-gradient(180deg, rgba(11, 16, 32, 0.82), rgba(11, 16, 32, 0.92));
       }
       html.dark {
         color-scheme: dark;
-        --clr-primary: #E21836; /* Super League Red */
-        --clr-primary-bright: #FF4D6D;
-        --clr-secondary: #FFDD57;
-        --clr-accent: #0074FF;
-        --clr-surface: #1F2023;
-        --clr-surface-alt: #161719;
-        --clr-text-strong: #FFFFFF;
-        --clr-text: #F3F4F6;
-        --clr-text-subtle: #CDD2D9;
-        --clr-border: #404040;
-        --gradient-1: linear-gradient(140deg, rgba(226, 24, 54, 0.2), rgba(0, 116, 255, 0.15));
-        --gradient-2: radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.18), transparent 60%);
-        --gradient-3: radial-gradient(circle at 90% 10%, rgba(226, 24, 54, 0.18), transparent 55%);
+        --clr-primary: #1E3A8A;
+        --clr-primary-600: #2563EB;
+        --clr-secondary: #2563EB;
+        --clr-accent: #F59E0B;
+        --clr-surface: #0F172A;
+        --clr-surface-alt: #111827;
+        --clr-text-strong: #F8FAFC;
+        --clr-text: #F8FAFC;
+        --clr-text-subtle: #CBD5E1;
+        --clr-brand-navy: #1E3A8A;
+        --clr-border: #334155;
+        --gradient-1: linear-gradient(140deg, rgba(30, 58, 138, 0.24), rgba(37, 99, 235, 0.16));
+        --gradient-2: radial-gradient(circle at 18% 20%, rgba(245, 158, 11, 0.22), transparent 58%);
+        --gradient-3: radial-gradient(circle at 78% -10%, rgba(11, 16, 32, 0.24), transparent 48%);
+        --app-background-overlay: linear-gradient(180deg, rgba(11, 16, 32, 0.9), rgba(11, 16, 32, 0.96));
       }
      html {
-        background-color: var(--clr-surface-alt);
-        background-image: var(--app-background-image);
+        background-color: var(--clr-surface-0);
+        background-image: var(--app-background-overlay), var(--app-background-image);
         background-size: cover;
         background-position: center;
         background-repeat: no-repeat;
@@ -56,11 +63,12 @@
       }
 
       html.dark {
-        background-color: #161719;
-        background-image: var(--app-background-image);
+        background-color: var(--clr-surface-0);
+        background-image: var(--app-background-overlay), var(--app-background-image);
       }
 
       body {
+        position: relative;
         background: inherit;
         background-size: cover;
         background-position: center;
@@ -114,6 +122,7 @@
           extend: {
             colors: {
               primary: 'var(--clr-primary)',
+              'primary-600': 'var(--clr-primary-600)',
               secondary: 'var(--clr-secondary)',
               accent: 'var(--clr-accent)',
               danger: 'var(--clr-danger)',
@@ -122,9 +131,13 @@
               success: 'var(--clr-success)',
               surface: 'var(--clr-surface)',
               'surface-alt': 'var(--clr-surface-alt)',
+              'surface-0': 'var(--clr-surface-0)',
+              'surface-1': 'var(--clr-surface-1)',
+              'surface-2': 'var(--clr-surface-2)',
               'text-strong': 'var(--clr-text-strong)',
-              'text': 'var(--clr-text)',
+              text: 'var(--clr-text)',
               'text-subtle': 'var(--clr-text-subtle)',
+              'brand-navy': 'var(--clr-brand-navy)',
               border: 'var(--clr-border)',
             },
             borderRadius: {
@@ -133,7 +146,7 @@
             },
             boxShadow: {
               card: '0 1px 2px rgba(0,0,0,.08), 0 4px 12px rgba(0,0,0,.06)',
-              focus: '0 0 0 2px rgba(226, 24, 54, .4)'
+              focus: '0 0 0 2px rgba(37, 99, 235, .45)'
             },
             fontFamily: {
               sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "name": "The Scrum Book",
+  "name": "The Turnstile",
    "description": "A web application for rugby league fans to track fixtures, log the games they've attended, and sync progress with Firebase when configured.",
   "requestFramePermissions": []
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleResolution": "Bundler",
     "strict": true,
     "baseUrl": ".",
-    "paths": { "*": ["./*"] }
+    "paths": { "*": ["./*"] },
+    "noEmit": true
   }
 }

--- a/utils/themeUtils.ts
+++ b/utils/themeUtils.ts
@@ -22,41 +22,41 @@ interface ThemeVariables {
 }
 
 const DEFAULT_LIGHT_THEME: ThemeVariables = {
-  primary: '#7F1028',
-  secondary: '#FFD447',
-  accent: '#0052CC',
-  danger: '#7F1028',
-  warning: '#FFD447',
-  info: '#0052CC',
-  success: '#00A86B',
-  textStrong: '#121212',
-  text: '#333333',
-  textSubtle: '#666666',
-  border: '#DDDDDD',
-  surface: '#FFFFFF',
-  surfaceAlt: '#F5F5F5',
-  gradient1: 'linear-gradient(140deg, rgba(127, 16, 40, 0.12), rgba(0, 82, 204, 0.1))',
-  gradient2: 'radial-gradient(circle at 20% 15%, rgba(255, 212, 71, 0.18), transparent 55%)',
-  gradient3: 'radial-gradient(circle at 80% 0%, rgba(127, 16, 40, 0.14), transparent 45%)',
+  primary: '#1E3A8A',
+  secondary: '#2563EB',
+  accent: '#F59E0B',
+  danger: '#EF4444',
+  warning: '#F59E0B',
+  info: '#2563EB',
+  success: '#06B6D4',
+  textStrong: '#0B1020',
+  text: '#1E3A8A',
+  textSubtle: '#334155',
+  border: '#334155',
+  surface: '#F8FAFC',
+  surfaceAlt: '#E2E8F0',
+  gradient1: 'linear-gradient(140deg, rgba(30, 58, 138, 0.12), rgba(37, 99, 235, 0.08))',
+  gradient2: 'radial-gradient(circle at 18% 20%, rgba(245, 158, 11, 0.16), transparent 56%)',
+  gradient3: 'radial-gradient(circle at 78% -10%, rgba(30, 58, 138, 0.14), transparent 48%)',
 };
 
 const DEFAULT_DARK_THEME: ThemeVariables = {
-  primary: '#B71E3C',
-  secondary: '#FFDD57',
-  accent: '#0074FF',
-  danger: '#B71E3C',
-  warning: '#FFDD57',
-  info: '#3B82F6',
-  success: '#22C55E',
-  textStrong: '#FFFFFF',
-  text: '#E0E0E0',
-  textSubtle: '#A0A0A0',
-  border: '#404040',
-  surface: '#1A1A1A',
-  surfaceAlt: '#2C2C2C',
-  gradient1: 'linear-gradient(140deg, rgba(183, 30, 60, 0.24), rgba(0, 116, 255, 0.18))',
-  gradient2: 'radial-gradient(circle at 15% 20%, rgba(255, 221, 87, 0.22), transparent 60%)',
-  gradient3: 'radial-gradient(circle at 90% 10%, rgba(183, 30, 60, 0.2), transparent 55%)',
+  primary: '#1E3A8A',
+  secondary: '#2563EB',
+  accent: '#F59E0B',
+  danger: '#EF4444',
+  warning: '#F59E0B',
+  info: '#2563EB',
+  success: '#06B6D4',
+  textStrong: '#F8FAFC',
+  text: '#F8FAFC',
+  textSubtle: '#CBD5E1',
+  border: '#334155',
+  surface: '#0F172A',
+  surfaceAlt: '#111827',
+  gradient1: 'linear-gradient(140deg, rgba(30, 58, 138, 0.24), rgba(37, 99, 235, 0.16))',
+  gradient2: 'radial-gradient(circle at 18% 20%, rgba(245, 158, 11, 0.22), transparent 58%)',
+  gradient3: 'radial-gradient(circle at 78% -10%, rgba(11, 16, 32, 0.24), transparent 48%)',
 };
 
 const VARIABLE_NAME_MAP: Record<keyof ThemeVariables, string> = {
@@ -252,7 +252,7 @@ const createTeamOverrides = (
 
   const primary = emphasisePrimaryColor(rawPrimary ?? branding.bg, mode);
 
-  const secondaryBase = rawSecondary ?? mixHexColors(primary, '#FFFFFF', mode === 'dark' ? 0.18 : 0.28);
+  const secondaryBase = rawSecondary ?? mixHexColors(primary, defaults.surface, mode === 'dark' ? 0.2 : 0.24);
   const accentBase = rawTertiary ?? rawSecondary ?? adjustColorIntensity(primary, {
     saturationMultiplier: 0.95,
     lightnessMultiplier: mode === 'dark' ? 1.22 : 0.88,
@@ -268,17 +268,17 @@ const createTeamOverrides = (
     lightnessMultiplier: mode === 'dark' ? 1.02 : 0.96,
   });
 
-  const warning = adjustColorIntensity(rawSecondary ?? mixHexColors(primary, '#F97316', 0.45), {
+  const warning = adjustColorIntensity(rawSecondary ?? mixHexColors(primary, defaults.warning, 0.4), {
     saturationMultiplier: 1.05,
     lightnessMultiplier: mode === 'dark' ? 1 : 0.98,
   });
 
-  const info = adjustColorIntensity(mixHexColors(accent, '#2563EB', 0.35), {
+  const info = adjustColorIntensity(mixHexColors(accent, defaults.info, 0.35), {
     saturationMultiplier: 1.05,
     lightnessMultiplier: mode === 'dark' ? 1 : 0.97,
   });
 
-  const success = adjustColorIntensity(mixHexColors(accent, '#16A34A', 0.4), {
+  const success = adjustColorIntensity(mixHexColors(accent, defaults.success, 0.4), {
     saturationMultiplier: 1.08,
     lightnessMultiplier: mode === 'dark' ? 1 : 0.97,
   });
@@ -288,8 +288,8 @@ const createTeamOverrides = (
     lightnessMultiplier: mode === 'dark' ? 1 : 0.92,
   });
 
-  const surface = mixHexColors(defaults.surface, primary, mode === 'dark' ? 0.12 : 0.07);
-  const surfaceAlt = mixHexColors(defaults.surfaceAlt, primary, mode === 'dark' ? 0.16 : 0.1);
+  const surface = mixHexColors(defaults.surface, primary, mode === 'dark' ? 0.12 : 0.04);
+  const surfaceAlt = mixHexColors(defaults.surfaceAlt, primary, mode === 'dark' ? 0.16 : 0.08);
 
   const gradient1 = `linear-gradient(135deg, ${hexToRgba(primary, mode === 'dark' ? 0.65 : 0.5)}, ${hexToRgba(accent, mode === 'dark' ? 0.52 : 0.35)})`;
   const gradient2 = `radial-gradient(circle at 18% 20%, ${hexToRgba(secondary, mode === 'dark' ? 0.5 : 0.32)}, transparent 56%)`;
@@ -299,7 +299,7 @@ const createTeamOverrides = (
     primary,
     secondary,
     accent,
-    danger: primary,
+    danger: defaults.danger,
     warning,
     info,
     success,


### PR DESCRIPTION
## Summary
- replace root CSS variables and Tailwind tokens with the mandated navy/amber palette
- recalibrate theme helpers and key screens to respect the new contrast rules for light and dark surfaces
- configure TypeScript to stop emitting transient JavaScript during builds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e63eb38d1c832ca26cc2e079947240